### PR TITLE
Add exports to change default output directories of makechrootpkg

### DIFF
--- a/common/ccm.skel
+++ b/common/ccm.skel
@@ -18,3 +18,8 @@ PACKAGER=""
 # Set this variable to anything if you want to run namcap on the built package
 # Leave it empty (default) if you do not want to run namcap
 RUNNAMCAP=
+
+# Uncomment and change paths to the directories where the output files should be placed
+#export PKGDEST=/scratch/pkgfiles
+#export SRCDEST=/scratch/sources
+#export LOGDEST=/scratch/pkgbuildlogs


### PR DESCRIPTION
Hi graysky, clean-chroot-manager is a cool script. Thanks for sharing :)

A small gripe: makechrootpkg dumps everything in the PKGBUILD folder. I prefer to keep that folder clean, so I keep all build outputs in their own folders (using makepkg.conf). This patch adds that ability to  clean-chroot-manager too.

See if this is cool enough to add.

Cheers!
