### PR TITLE
Build function return fix

### DIFF
--- a/common/clean-chroot-manager32.in
+++ b/common/clean-chroot-manager32.in
@@ -168,6 +168,12 @@ EOF
 		# more than once
 		[[ -f "/var/cache/pacman/pkg/$i" ]] && rm -f "/var/cache/pacman/pkg/$i"
 	done
+
+	# The rm statement above can return 1 if the file to remove is not found,
+	# causing the function to return a non-zero error code even if everything
+	# went fine.  If we've made it to this point, the build was run
+	# successfully, so return 0 instead
+	return 0
 }
 
 update() {

--- a/common/clean-chroot-manager64.in
+++ b/common/clean-chroot-manager64.in
@@ -180,6 +180,12 @@ EOF
 		# more than once
 		[[ -f "/var/cache/pacman/pkg/$i" ]] && rm -f "/var/cache/pacman/pkg/$i"
 	done
+
+	# The rm statement above can return 1 if the file to remove is not found,
+	# causing the function to return a non-zero error code even if everything
+	# went fine.  If we've made it to this point, the build was run
+	# successfully, so return 0 instead
+	return 0
 }
 
 update() {


### PR DESCRIPTION
I've been building a script around `ccm` to run over a list of packages and build any that are out of date.  In the process, I've discovered that the `build()` function (or `ccm s`) has a non-zero return value whenever you build something that is not in the local (non-chrooted) pacman package cache, even if the build ran successfully.

For me, this is undesirable from a scripting perspective, and I assume that this isn't your intent.  The fix is very simple, and added in commit 4ca9b36

The only other source of error that this may miss is a problem during the `repo-add` command, which currently is not checked for.  I think I will submit a different pull request fixing that, since that is a separate issue and I'm not sure how you would like to handle that.  EDIT: I've submitted a fix for this in #8.

Let me know if you would like me to do something differently, I would be happy to modify the pull request.

Cheers.
