### PR TITLE
Exit on repo-add errors

### DIFF
--- a/common/clean-chroot-manager32.in
+++ b/common/clean-chroot-manager32.in
@@ -161,7 +161,7 @@ EOF
 	echo -e "${YELLOW}---->${ALL_OFF}${BOLD} ${mesg}${ALL_OFF}"
 	for i in *.pkg.tar.xz; do
 		cp "$i" $REPO
-		repo-add $REPO/chroot_local.db.tar.gz $REPO/"$i"
+		repo-add $REPO/chroot_local.db.tar.gz $REPO/"$i" || exit 1
 
 		# insure that the chroot package matches the live pacman cache package
 		# which avoids checksum errors if the user builds the same $pkgname-$pkgver

--- a/common/clean-chroot-manager64.in
+++ b/common/clean-chroot-manager64.in
@@ -173,7 +173,7 @@ EOF
 	for i in *.pkg.tar.xz; do
 
 		cp "$i" $REPO
-		repo-add $REPO/chroot_local.db.tar.gz $REPO/"$i"
+		repo-add $REPO/chroot_local.db.tar.gz $REPO/"$i" || exit 1
 
 		# insure that the chroot package matches the live pacman cache package
 		# which avoids checksum errors if the user builds the same $pkgname-$pkgver


### PR DESCRIPTION
I mentioned in #7 that any error in `repo-add` would be missed.  This patch fixes this.

In practice, this would mean that the `cp` statement failed for some odd reason (probably disk space), but it would be nice to represent that "something bad" happened in the return code in this event.

Again, let me know if you want this done differently, I'm happy to change the anything.
