### PR TITLE
Fix build() and buildnc() exit codes

### DIFF
--- a/common/clean-chroot-manager32.in
+++ b/common/clean-chroot-manager32.in
@@ -157,7 +157,7 @@ build() {
 	fi
 
 	# stop here if build fails
-	[[ $? -gt 0 ]] && exit 1
+	[[ $? -eq 0 ]] || exit 1
 }
 
 buildnc() {
@@ -172,7 +172,7 @@ buildnc() {
 	fi
 
 	# stop here if build fails
-	[[ $? -gt 0 ]] && exit 1
+	[[ $? -eq 0 ]] || exit 1
 }
 
 indexit() {

--- a/common/clean-chroot-manager64.in
+++ b/common/clean-chroot-manager64.in
@@ -168,7 +168,7 @@ build() {
 	fi
 
 	# stop here if build fails
-	[[ $? -gt 0 ]] && exit 1
+	[[ $? -eq 0 ]] || exit 1
 }
 
 buildnc() {
@@ -183,7 +183,7 @@ buildnc() {
 	fi
 
 	# stop here if build fails
-	[[ $? -gt 0 ]] && exit 1
+	[[ $? -eq 0 ]] || exit 1
 }
 
 indexit() {


### PR DESCRIPTION
Both functions check whether the exit code of makechrootpkg is >0 and if
the test succeeds (i.e. makechrootpkg failed), force the script to fail.
Unfortunately, this means that if makechrootpkg exited cleanly, then the
above test fails ([[ $? -ge 0 ]] ==> false). But with the test being the
last command in each function, the functions now also return false --
while exactly the opposite should have happened.

This commit reverses the test logic: instead of checking whether the
makechrootpkg exit code is >0, it tests whether it equals 0 and fails
the script on test failure. If makechrootpkg exited cleanly, the test
succeeds ([[ $? -eq 0 ]] ==> true) and the functions also return true.
This fixes e.g. indexit() not being executed after build() success.
