### PR TITLE
Fixed the nuke() method when running on a btrfs filesystem. Fix Bug when PKGDEST is set in makepkg.conf

### DIFF
--- a/common/clean-chroot-manager32.in
+++ b/common/clean-chroot-manager32.in
@@ -374,7 +374,17 @@ header() {
 nuke() {
 	local mesg="Nuking the chroot..."
 	echo -e "${GREEN}==>${ALL_OFF}${BOLD} ${mesg}${ALL_OFF}"
-	rm -rf $CHROOTPATH32/*
+	if [[ $(stat -f -c %T "$CHROOTPATH32") == btrfs ]]; then
+		for i in $CHROOTPATH32/*; do
+			if [ -d $i ]; then
+				btrfs subvolume delete $i
+			else
+				rm -f $i
+			fi
+		done
+	else
+		rm -rf $CHROOTPATH32/*
+	fi
 }
 
 check

--- a/common/clean-chroot-manager32.in
+++ b/common/clean-chroot-manager32.in
@@ -266,12 +266,19 @@ indexit() {
 	local mesg="Adding package to chroot repo..."
 	echo -e "${YELLOW}---->${ALL_OFF}${BOLD} ${mesg}${ALL_OFF}"
 
+	# find out if the user has $PKGDEST set in the makepkg.conf file
+	# and then copy the variable.
+	PKGDEST="$(grep "^PKGDEST=" /etc/makepkg.conf|cut -d '=' -f 2)"
+	if [ ! -z "$PKGDEST" ]; then
+		PKGDEST="${PKGDEST}/"
+	fi
+
 	# it could be that the user is building for both i686 and x86_64
 	# in which case we don't want to pollute the pure i686 repo
 	# with x86_64 packages so only process 'i686' and 'any' types
-	for i in $(ls *.pkg.tar.xz | sed '/-x86_64.pkg.tar.xz/d'); do
+	for i in $(ls ${PKGDEST}*.pkg.tar.xz | sed '/-x86_64.pkg.tar.xz/d'); do
 		cp "$i" $REPO
-		repo-add $REPO/chroot_local.db.tar.gz $REPO/"$i" || exit 1
+		repo-add $REPO/chroot_local.db.tar.gz $REPO/"$(basename $i)" || exit 1
 
 		# ensure that the chroot package matches the live pacman cache package
 		# which avoids checksum errors if the user builds the same $pkgname-$pkgver
@@ -377,7 +384,7 @@ nuke() {
 	if [[ $(stat -f -c %T "$CHROOTPATH32") == btrfs ]]; then
 		for i in $CHROOTPATH32/*; do
 			if [ -d $i ]; then
-				btrfs subvolume delete $i
+				btrfs subvolume delete $i > /dev/null
 			else
 				rm -f $i
 			fi

--- a/common/clean-chroot-manager64.in
+++ b/common/clean-chroot-manager64.in
@@ -409,7 +409,17 @@ header() {
 nuke() {
 	local mesg="Nuking the chroot..."
 	echo -e "${GREEN}==>${ALL_OFF}${BOLD} ${mesg}${ALL_OFF}"
-	rm -rf $CHROOTPATH64/*
+	if [[ $(stat -f -c %T "$CHROOTPATH64") == btrfs ]]; then
+		for i in $CHROOTPATH64/*; do
+			if [ -d $i ]; then
+				btrfs subvolume delete $i
+			else
+				rm -f $i
+			fi
+		done
+	else
+		rm -rf $CHROOTPATH64/*
+	fi
 }
 
 check

--- a/common/clean-chroot-manager64.in
+++ b/common/clean-chroot-manager64.in
@@ -270,12 +270,19 @@ indexit() {
 	local mesg="Adding package to chroot repo..."
 	echo -e "${YELLOW}---->${ALL_OFF}${BOLD} ${mesg}${ALL_OFF}"
 
+	# find out if the user has $PKGDEST set in the makepkg.conf file
+	# and then copy the variable.
+	PKGDEST="$(grep "^PKGDEST=" /etc/makepkg.conf|cut -d '=' -f 2)"
+	if [ ! -z "$PKGDEST" ]; then
+		PKGDEST="${PKGDEST}/"
+	fi
+
 	# it could be that the user is building for both i686 and x86_64
 	# in which case we don't want to pollute the pure x86_64 repo
 	# with i686 packages so only process 'x86_64' and 'any' types
-	for i in $(ls *.pkg.tar.xz | sed '/-i686.pkg.tar.xz/d'); do
+	for i in $(ls ${PKGDEST}*.pkg.tar.xz | sed '/-i686.pkg.tar.xz/d'); do
 		cp "$i" $REPO
-		repo-add $REPO/chroot_local.db.tar.gz $REPO/"$i" || exit 1
+		repo-add $REPO/chroot_local.db.tar.gz $REPO/"$(basename $i)" || exit 1
 
 		# ensure that the chroot package matches the live pacman cache package
 		# which avoids checksum errors if the user builds the same $pkgname-$pkgver
@@ -412,7 +419,7 @@ nuke() {
 	if [[ $(stat -f -c %T "$CHROOTPATH64") == btrfs ]]; then
 		for i in $CHROOTPATH64/*; do
 			if [ -d $i ]; then
-				btrfs subvolume delete $i
+				btrfs subvolume delete $i > /dev/null
 			else
 				rm -f $i
 			fi


### PR DESCRIPTION
Because mkarchchroot defaults to create btrfs subvolumes on
a btrfs filesystem, ccm could not simply
rm -rf CHROOTPATH{64,32}/* before.
This patch correctly removes the subvolumes.

Signed-off-by: Michael Düll <michael.duell@rub.de>