### PR TITLE
Use GLOBIGNORE in repo-add loop

### DIFF
--- a/common/clean-chroot-manager32.in
+++ b/common/clean-chroot-manager32.in
@@ -265,6 +265,7 @@ indexit() {
   # it could be that the user is building for both i686 and x86_64
   # in which case we don't want to pollute the pure i686 repo
   # with x86_64 packages so only process 'i686' and 'any' types
+  GLOBIGNORE="*namcap.log"
   for i in *.pkg.tar*; do
     if [[ "$i" = *x86_64.pkg.tar* ]]; then
       continue
@@ -278,6 +279,7 @@ indexit() {
       [[ -f "/var/cache/pacman/pkg/$i" ]] && rm -f "/var/cache/pacman/pkg/$i"
     fi
   done
+  unset GLOBIGNORE
 
   # The rm statement above can return 1 if the file to remove is not found,
   # causing the function to return a non-zero error code even if everything

--- a/common/clean-chroot-manager64.in
+++ b/common/clean-chroot-manager64.in
@@ -295,6 +295,7 @@ indexit() {
   # it could be that the user is building for both i686 and x86_64
   # in which case we don't want to pollute the pure x86_64 repo
   # with i686 packages so only process 'x86_64' and 'any' types
+  GLOBIGNORE="*namcap.log"
   for i in *.pkg.tar*; do
     if [[ "$i" = *i686.pkg.tar* ]]; then
       continue
@@ -308,6 +309,7 @@ indexit() {
       [[ -f "/var/cache/pacman/pkg/$i" ]] && rm -f "/var/cache/pacman/pkg/$i"
     fi
   done
+  unset GLOBIGNORE
 
   # The rm statement above can return 1 if the file to remove is not found,
   # causing the function to return a non-zero error code even if everything


### PR DESCRIPTION
Globbing introduced in 1bdc3e770923f6b2633d3b77b282aee4c58b2aa0 means that any file containing ".pkg.tar" is included in the repo-add loop post-package build. This includes namcap logs, resulting in error messages such as:

==> ERROR: '/scratch/chroot64/root/repo/tmux-git-debug-2.3.r163.g2864a31-1-x86_64.pkg.tar.xz-namcap.log' is not a package file, skipping

By using GLOBIGNORE, we can explicitly ignore any files that end with "namcap.log".