### PR TITLE
add option to specify local repo outside of clean-chroot

### DIFF
--- a/common/ccm.skel
+++ b/common/ccm.skel
@@ -64,6 +64,11 @@ DISTCC_HOSTS="localhost/9 foo/8 bar/4"
 #CUSTOM_PACMAN_CONF='/usr/share/devtools/pacman-extra.conf'
 #CUSTOM_MAKEPKG_CONF='/usr/share/devtools/makepkg-x86_64.conf'
 
+# Optionally uncomment and define a custom location and name for the local chroot
+# package repo. 
+#REPO='$CHROOTPATH64/root/repo'
+#REPO_NAME='chroot_local'
+
 # If set, the value defined will be used in the buildroot's packages.
 # Note that CFLAGS will be mirrored automatically to define the CXXFLAGS.
 #

--- a/common/clean-chroot-manager64.in
+++ b/common/clean-chroot-manager64.in
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 #
 # clean-chroot-manager by graysky
 #
@@ -94,7 +93,25 @@ check() {
     fi
 
     # if user defined a trailing slash remove it here
-    REPO="${CHROOTPATH64%/}/root/repo"
+    if [[ -n "$REPO" ]]; then
+      REPO="${REPO%/}"
+      # check that external repo actually exists
+      if [[ ! -d "$REPO" ]]; then
+        local mesg="The external repo configured in $CFGFILE does not exist. Please create the path first."
+        echo -e "${RED}==> ERROR:${ALL_OFF}${BOLD} ${mesg}${ALL_OFF}" && exit 1
+      fi
+      # check write permissions for external path
+      if sudo -u "$USER" -H sh -c "[ ! -w \"$REPO\" ]"; then
+        local mesg="User $USER has no write permissions on $REPO"
+        echo -e "${RED}==> ERROR:${ALL_OFF}${BOLD} ${mesg}${ALL_OFF}" && exit 1
+      fi
+    else
+      REPO="${CHROOTPATH64%/}/root/repo"
+    fi
+    
+    if [[ -z "$REPO_NAME" ]]; then
+      REPO_NAME="chroot_local"
+    fi
 
     if ! [[ "$THREADS" =~ ^[0-9]+$ ]]; then
       local mesg="Invalid setting for THREADS defined in $SKEL"
@@ -237,10 +254,10 @@ build() {
 indexit() {
   # if this is the first time a package has been successfully built,
   # append the local repo to the buildroot's pacman.conf
-  if ! grep -q clean-chroot "$CHROOTPATH64"/root/etc/pacman.conf; then
+  if ! grep -q "$REPO_NAME" "$CHROOTPATH64"/root/etc/pacman.conf; then
     # add a local repo to buildroot
     sed -i "/\[testing\]/i \
-      # Added by clean-chroot-manager\n[chroot_local]\nSigLevel = Never\nServer = file://$REPO\n" \
+      # Added by clean-chroot-manager\n[$REPO_NAME]\nSigLevel = Never\nServer = file://$REPO\n" \
           "$CHROOTPATH64"/root/etc/pacman.conf
   fi
 
@@ -255,7 +272,7 @@ indexit() {
   GLOBIGNORE="*namcap.log"
   for i in *.pkg.tar*; do
     cp "$i" "$REPO"
-    repo-add "$REPO"/chroot_local.db.tar.gz "$REPO/$i" || exit 1
+    repo-add "$REPO"/"$REPO_NAME".db.tar.gz "$REPO/$i" || exit 1
 
     # make sure that the buildroot package matches the live pacman cache package
     # to avoid a checksum error if the user builds the same package wo/ bumping the pkgver
@@ -272,17 +289,23 @@ indexit() {
 
 syncup() {
   # make sure the user copy and root copy of the repo are in parity since invoking
-  # without the -c switch will not on its own
-  [[ -d "$REPO" ]] &&
+  # without the -c switch will not on its own, but only if the repo resides in the chroot
+  [[ "$REPO" == "${CHROOTPATH64%/}/root/repo" ]] &&  [[ -d "$REPO" ]] &&
     rsync -ax "$REPO"/ "${CHROOTPATH64%/}/$USER"/repo/
 
   # also need a safeguard for users invoking `ccm S` once a fresh buildroot to ensure
   # that the user's pacman.conf also contains the entry for [chroot_local]
-  if ! grep -q clean-chroot "$CHROOTPATH64/$USER"/etc/pacman.conf; then
+  if ! grep -q "$REPO_NAME" "$CHROOTPATH64/$USER"/etc/pacman.conf; then
     # add a local repo to buildroot
-    sed -i "/\[testing\]/i \
+    if $REPO="${CHROOTPATH64%/}/root/repo"; then
+      sed -i "/\[testing\]/i \
       # Added by clean-chroot-manager\n[chroot_local]\nSigLevel = Never\nServer = file://${CHROOTPATH64%/}/$USER/repo\n" \
           "${CHROOTPATH64%/}/$USER"/etc/pacman.conf
+    else
+      sed -i "/\[testing\]/i \
+      # Added by clean-chroot-manager\n["$REPO_NAME"]\nSigLevel = Never\nServer = file://$REPO\n" \
+          "${CHROOTPATH64%/}/$USER"/etc/pacman.conf
+    fi
   fi
 }
 
@@ -293,7 +316,7 @@ update() {
 }
 
 repocheck() {
-  if [[ ! -f "$REPO/chroot_local.db.tar.gz" ]]; then
+  if [[ ! -f "$REPO/$REPO_NAME.db.tar.gz" ]]; then
     local mesg="Local repo in buildroot is empty. Build something first."
     echo -e "${RED}==> ERROR:${ALL_OFF}${BOLD} ${mesg}${ALL_OFF}"
     exit 1
@@ -506,6 +529,7 @@ distcc_check() {
     # need to prefix the call to makechrootpkg with threads value
     # https://bugs.archlinux.org/task/64349
     THREADS=$DISTCC_THREADS
+
   fi
 }
 


### PR DESCRIPTION
As discussed in #67, here are the changes I made to my local build in order to facilitate my workflow.

This adds an option (defaulting to the current setting) of specifying a name and a location for a local pacman repo. If set in the config, this repo will be used by ccm to store and recall build packages. If unmodified, the current behaviour of ccm persists.

I have tested and used these patches for a bit now and they seem to be working - I use paru with a local repo to manage my AUR packages and my modified ccm build the packages I maintain myself (locally and on the AUR) into that same local repo. Seems to work fine, but I am always open to learning opportunities regarding my ... questionable ... coding skills.