### PR TITLE
fix possible issue with users only setting  but not REPO but not REPO_NAME

### DIFF
--- a/common/clean-chroot-manager64.in
+++ b/common/clean-chroot-manager64.in
@@ -295,9 +295,9 @@ syncup() {
   # that the user's pacman.conf also contains the entry for [chroot_local]
   if ! grep -q "$REPO_NAME" "$CHROOTPATH64/$USER"/etc/pacman.conf; then
     # add a local repo to buildroot
-    if REPO_NAME="chroot_local"; then
+    if REPO="${CHROOTPATH64%/}/root/repo"; then
       sed -i "/\[testing\]/i \
-        # Added by clean-chroot-manager\n[chroot_local]\nSigLevel = Never\nServer = file://${CHROOTPATH64%/}/$USER/repo\n" \
+        # Added by clean-chroot-manager\n["$REPO_NAME"]\nSigLevel = Never\nServer = file://${CHROOTPATH64%/}/$USER/repo\n" \
         "${CHROOTPATH64%/}/$USER"/etc/pacman.conf
      else
       sed -i "/\[testing\]/i \


### PR DESCRIPTION
I think I found one possible issue, corrected below: In case a user only uses a custom $REPO, but leaves $REPO_NAME unchanged, the old code would end up setting the wrong repo location in the /chroot/$user directory.

This should hopefully prevent that.