### PR TITLE
fix repackage

### DIFF
--- a/common/clean-chroot-manager64.in
+++ b/common/clean-chroot-manager64.in
@@ -594,7 +594,7 @@ case "$1" in
     # flag to NOT add a '-c' to the args array
     CLEANIT=0
 
-    check_config && check_active && build && indexit && syncup
+    check_active && build && indexit && syncup
     ;;
   s)
     check_config && check_active && distcc_check


### PR DESCRIPTION
The message "ERROR: User xxx has no write permissions on /path/to/repo" is printed when using the repackage action.
This commit fixes this issue by removing a redundant call to check_config.