### PR TITLE
use XDG_CONFIG_HOME in CFGFILE

### DIFF
--- a/common/clean-chroot-manager64.in
+++ b/common/clean-chroot-manager64.in
@@ -52,7 +52,7 @@ HOMEDIR="$(getent passwd "$USER" | cut -d: -f6)"
 
 # allow user to override from cli thus using multiple files as needed
 XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOMEDIR/.config}"
-CFGFILE=${CFGFILE:-$HOMEDIR/.config/$PKG.conf}
+CFGFILE=${CFGFILE:-$XDG_CONFIG_HOME/$PKG.conf}
 
 # dependency checks probably not needed but they do not hurt
 if ! command -v mkarchroot >/dev/null 2>&1; then


### PR DESCRIPTION
In line 54 XDG_CONFIG_HOME is assigned, but not used in the next line. It is used later on, though.